### PR TITLE
Match he_pin in config with schematics in README

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ spi_port = 0
 spi_dev = 0
 
 # Pin # for relay connected to heating element
-he_pin = 26
+he_pin = 7
 
 # Default goal temperature
 set_temp = 221.


### PR DESCRIPTION
It is incredibly confusing that the schematics in the README show the he_pin to be physical pin 26 / GPIO7 while the GPIO mode is set to BCM and thus the he_pin in config.py should be set to 7 and not 26.